### PR TITLE
Toggle default is OFF, and previous state save

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,11 @@
 						"aligned by the top of the view range",
 						"aligned by the scrolled lines offset"
 					]
+				},
+				"syncScroll.saveRecentToggleState": {
+					"type": "boolean",
+					"description": "Save recent toggle state to workspace state.",
+					"default": false
 				}
 			}
 		}


### PR DESCRIPTION
Nice to meet you.
I am also using your extension. Thank you.

Well, I found issue #3, and I agreed, so I tried making the following changes.

* Changed the default of `Toggle State` to `OFF`.
* Save `Toggle State` in workspaceState.
* Enabled to set whether to save to `workspaceState`.
* Other fixes related to the above.

We would appreciate if you could consider this change.

Also, if the above does not cause any problems, I think it is better to make the following changes as well.

* Save `syncScroll.mode` in `ExtensionContext.workspaceState` as well as `ToggleState`

---

This sentence is translated into English using Google Translate.
It may be strange. Please pardon.

Best regards